### PR TITLE
remove hard coded setting to log to file

### DIFF
--- a/dc_config/images/celery/startCeleryWorker
+++ b/dc_config/images/celery/startCeleryWorker
@@ -9,4 +9,4 @@ for itm in os.environ.get("CELERY_SOURCE").split(','):
 celery_queue=os.environ.get("CELERY_QUEUE","celery")
 log_level=os.environ.get("LOG_LEVEL","INFO")
 
-call(["su", "-p", "celery", "-c", "celery -f celery.log -Q {0} -l {1} worker".format(celery_queue,log_level)])
+call(["su", "-p", "celery", "-c", "celery -Q {0} -l {1} worker".format(celery_queue,log_level)])


### PR DESCRIPTION
The previous setting prevented logging to docker / docker-compose managed logs.

This removes that setting and allows access to celery logs from docker-compose logs.